### PR TITLE
data entity is now able to detect parents

### DIFF
--- a/webapp-bundle/src/main/resources/mapping/extension/readonly/DataResource.hbm.xml
+++ b/webapp-bundle/src/main/resources/mapping/extension/readonly/DataResource.hbm.xml
@@ -11,6 +11,7 @@
         <property column="phenomenontime" name="timestart" type="timestamp"/>
         <property column="phenomenontime" name="timeend" type="timestamp" insert="false" update="false"/>
         <property formula="'F'" name="deleted" type="org.hibernate.type.TrueFalseType"/>
+        <property formula="'F'" name="parent" type="org.hibernate.type.TrueFalseType"/>
         <component class="GeometryEntity" name="geometryEntity">
            <property column="lat" name="lat" type="double" />
            <property column="lon" name="lon" type="double" />


### PR DESCRIPTION
With the feature to [support of `profile` observations](https://github.com/52North/dao-series-api/pull/31) the [DAO SPI Impl](https://github.com/52North/dao-series-api) module needs to create data queries on a `parent` property. For HZG this has to be set to `FALSE` by default.